### PR TITLE
Fixed SSRF bug in CairoSVG

### DIFF
--- a/cairosvg/url.py
+++ b/cairosvg/url.py
@@ -81,6 +81,9 @@ def fetch(url, resource_type):
     image/*, image/svg+xml, text/css).
 
     """
+    blacklist = ['localhost', '127.0.0.1', '[::]', '0000::1', '[0:0:0:0:0:ffff:127.0.0.1]']
+    if(any(link in url for link in blacklist)):
+        return None
     return urlopen(Request(url, headers=HTTP_HEADERS)).read()
 
 


### PR DESCRIPTION
### 📊 Metadata *
Server Side Request Forgery

#### Bounty URL:  https://www.huntr.dev/bounties/1-pip-CairoSVG/

### ⚙️ Description *

`CairoSVG` is an SVG converter based on Cairo. It can export SVG files to PDF, EPS, PS, and PNG files.
Affected versions of this package used in web apps can be lead to Server-side request forgery attacks.

### 💻 Technical Description *

The `url` is not validated when fetching the data. abusing this, an attacker can access or manipulate information in the realm of that server that would otherwise not be directly accessible. The fix is to check whether the request is made to the localhost itself before processing. Here, an array of blacklisted URLs are implemented.

### 🐛 Proof of Concept (PoC) *

* `$ pip3 install cairosvg`
* `$ cairosvg payload.svg`

**payload.svg**
```svg
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<svg xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="overflow: hidden; position: relative;" width="300" height="200">
<image x="10" y="10" width="276" height="110" xlink:href="http://localhost:8080/svg" stroke-width="1" id="image3204" />
<rect x="0" y="150" height="10" width="300" style="fill: black"/>
</svg>
```

* Listen at localhost:8080

![image](https://user-images.githubusercontent.com/16708391/102808707-c2857f80-43e6-11eb-862f-b391c23ba6a1.png)


### 🔥 Proof of Fix (PoF) *

After applying the fix, SSRF attacks can be mitigated.

![image](https://user-images.githubusercontent.com/16708391/102808879-1001ec80-43e7-11eb-807f-27c744be8e08.png)

### 👍 User Acceptance Testing (UAT)

Just validated the `url`, no breaking changes introduced 👍 
